### PR TITLE
Fix deadlock in dice sending

### DIFF
--- a/pkg/common/sending/entities.go
+++ b/pkg/common/sending/entities.go
@@ -97,6 +97,7 @@ func (s *sendDice) SendToTelegram(token string) error {
 	sdr := SendDiceToRequest(s)
 	response, err := client.SendDice(token, sdr)
 	if err != nil {
+		close(s.done)
 		return err
 	}
 	s.value = response.Dice.Value


### PR DESCRIPTION
## Summary
- avoid hanging when SendDice call fails by closing `done`

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68488d05586c833393398f55d6e4f809